### PR TITLE
Ensure superclass is set correctly when reopening Spree::Gateway::BraintreeGateway.

### DIFF
--- a/app/models/spree/gateway/braintree_gateway_decorator.rb
+++ b/app/models/spree/gateway/braintree_gateway_decorator.rb
@@ -1,7 +1,17 @@
 module Spree
-  class Gateway::BraintreeGateway
+  class Gateway::BraintreeGateway < Gateway
     concerning :CSE do
       included do
+
+        # Define `options_for_payment` here like this because, if Rails reloads
+        # this befre spree_gateway, ruby may not know we're a child of Gateway
+        # and `alias_method_chain :options_for_payment, :cse` won't be able to
+        # access `Spree::Gateway::BraintreeGateway#options_for_payment` because
+        # it is a protected method.
+        def options_for_payment(p)
+          super
+        end
+
         unless method_defined? :options_for_payment_without_cse
           preference :use_client_side_encryption, :boolean
           alias_method_chain :authorize, :cse

--- a/spree_braintree-cse.gemspec
+++ b/spree_braintree-cse.gemspec
@@ -2,7 +2,7 @@
 Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.name        = 'spree_braintree_cse'
-  s.version     = '2.3.11'
+  s.version     = '2.3.12'
   s.summary     = 'Braintree for Spree with Client-Side Encryption support'
   s.description = ''
   s.required_ruby_version = '>= 1.9.3'


### PR DESCRIPTION
Also add fake `options_for_select` to get around alias_method_chain issue. There is probably a better solution for this problem hiding in plain sight, but I haven't found it yet. It probably involves using `require_dependency` or changing the gemspec file, but I wasn't able to find the right combination.


Part of https://trello.com/c/dcnJAAFW/3964-1-nibley-reloading-problem-fixes