### PR TITLE
Check if method exists before calling alias_method_chain on it

### DIFF
--- a/app/models/spree/gateway/braintree_gateway_decorator.rb
+++ b/app/models/spree/gateway/braintree_gateway_decorator.rb
@@ -3,19 +3,17 @@ module Spree
     concerning :CSE do
       included do
 
-        # Define `options_for_payment` here like this because, if Rails reloads
-        # this befre spree_gateway, ruby may not know we're a child of Gateway
-        # and `alias_method_chain :options_for_payment, :cse` won't be able to
-        # access `Spree::Gateway::BraintreeGateway#options_for_payment` because
-        # it is a protected method.
-        def options_for_payment(p)
-          super
-        end
-
         unless method_defined? :options_for_payment_without_cse
           preference :use_client_side_encryption, :boolean
           alias_method_chain :authorize, :cse
-          alias_method_chain :options_for_payment, :cse
+
+          if method_defined? :options_for_payment
+            # Check if `#options_for_payment` exist before trying to alias it
+            # because, if the app is reloaded in development, then the method
+            # will have already been moved and `alias_method_chain` will fail.
+            alias_method_chain :options_for_payment, :cse
+          end
+
         end
       end
 


### PR DESCRIPTION
Change from using a placeholder `#options_for_select` to checking if that method exists before trying to call `alias_method_chain` on it.

https://trello.com/c/K6SwSma5/4048-0-5-fix-spree-braintree-cse-in-production-mode